### PR TITLE
Feature open project

### DIFF
--- a/src/com/shep/editor/NewProjectFrame.java
+++ b/src/com/shep/editor/NewProjectFrame.java
@@ -66,6 +66,7 @@ public class NewProjectFrame extends JFrame {
 
         this.btnNewProject.addActionListener(e -> {
             if (!texFldProjectName.getText().isBlank() && !texFldProjectPath.getText().isBlank()) {
+                // TODO: Change logic, we should set project only if project could be created
                 p_parentFrame.SetProject(new Project(texFldProjectName.getText(), texFldProjectPath.getText()));
                 p_parentFrame.CreateProject();
                 this.setVisible(false);

--- a/src/com/shep/editor/OpenProjectFrame.java
+++ b/src/com/shep/editor/OpenProjectFrame.java
@@ -1,0 +1,28 @@
+package com.shep.editor;
+
+import com.shep.model.Project;
+
+import javax.swing.*;
+import java.io.File;
+import java.nio.file.Paths;
+
+public class OpenProjectFrame {
+    private JFileChooser fileChooser;
+
+    public OpenProjectFrame(ProjectFrame p_parentFrame) {
+        String projectPath = Paths.get(Project.DEFAULT_PATH).toFile().exists() ?
+                                Project.DEFAULT_PATH : System.getProperty("user.home");
+
+        this.fileChooser = new JFileChooser();
+        this.fileChooser.setCurrentDirectory(new File(projectPath));
+        // TODO: User shouldn't be allowed to open any folder as a project
+        this.fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        int res = fileChooser.showOpenDialog(p_parentFrame);
+
+        if (res == JFileChooser.APPROVE_OPTION) {
+            String openedDir = fileChooser.getSelectedFile().getAbsolutePath();
+            String projectName = openedDir.substring(openedDir.lastIndexOf(File.separator)+1);
+            p_parentFrame.SetProject(new Project(projectName, openedDir));
+        }
+    }
+}

--- a/src/com/shep/editor/ProjectFrame.java
+++ b/src/com/shep/editor/ProjectFrame.java
@@ -37,6 +37,7 @@ public class ProjectFrame extends JFrame {
         this.fileNew.addActionListener(a -> new NewProjectFrame(this));
         this.fileNew.setMnemonic('n');
         this.fileOpen = new JMenuItem("Open Project");
+        this.fileOpen.addActionListener(a -> new OpenProjectFrame(this));
         this.fileOpen.setMnemonic('o');
 
         this.menuFile.add(fileNew);
@@ -47,6 +48,7 @@ public class ProjectFrame extends JFrame {
     }
 
     public void SetProject(Project p_project) {
+        //TODO: We'll probably want  save and close the previous project here
         this.workedProject = new Project(p_project);
         this.setTitle(Main.GetTitle() + " - " + workedProject.GetName());
     }


### PR DESCRIPTION
# Description
Created a new class to open a file chooser. It allows the user to open any directory (at the moment) to use it as a project. 
Some changes will be needed later down the line to ensure the user is opening a proper project. However this isn't a problem for version 0.2.0.

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
* Tested to open a project => no crash + project opened as project
* Tested to open a random directory => no crash + random directory opened as project (this behavior should be removed later on)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation when applicable
- [X] My changes generate no new warnings
